### PR TITLE
Fix series generation tuple length

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -24,8 +24,22 @@ def generate_series(series_id, size):
         lat, lon = generate_random_coordinates()
         username = generate_random_name()
         text = f"Серия {series_id}, записка {i}/{size}"
-        # Добавить данные в список серии
-        series.append((username, text, lat, lon, None, None, series_id, i))
+        # Добавить данные в список серии. Порядок полей:
+        # username, text, latitude, longitude, address,
+        # nearest_metro, metro_distance, series_id, series_order
+        series.append(
+            (
+                username,
+                text,
+                lat,
+                lon,
+                None,  # address
+                None,  # nearest_metro
+                None,  # metro_distance
+                series_id,
+                i,
+            )
+        )
     return series
 
 def generate_random_notes(count):


### PR DESCRIPTION
## Summary
- fix `generate_series` tuples to include metro distance field

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff9d1319883249632b3a190e6d2ba