### PR TITLE
Update widget test for NotesApp

### DIFF
--- a/my_notes_app/test/widget_test.dart
+++ b/my_notes_app/test/widget_test.dart
@@ -11,20 +11,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:my_notes_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('initial login screen is shown', (WidgetTester tester) async {
+    // Build the app and trigger a frame.
+    await tester.pumpWidget(const NotesApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the login screen title is present.
+    expect(find.text('Вход'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- use `NotesApp` in widget test
- check that the login screen loads

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_683ffcd7790483248caed2b646c84fcc