### PR TITLE
Fix generate_series tuple format

### DIFF
--- a/server/utils.py
+++ b/server/utils.py
@@ -24,8 +24,12 @@ def generate_series(series_id, size):
         lat, lon = generate_random_coordinates()
         username = generate_random_name()
         text = f"Серия {series_id}, записка {i}/{size}"
-        # Добавить данные в список серии
-        series.append((username, text, lat, lon, None, None, series_id, i))
+        # Добавить данные в список серии. Кортеж содержит девять элементов:
+        # username, text, latitude, longitude, address,
+        # nearest_metro, metro_distance, series_id, series_order.
+        # Для metro_distance подставляем None, чтобы структура
+        # соответствовала формату базы данных.
+        series.append((username, text, lat, lon, None, None, None, series_id, i))
     return series
 
 def generate_random_notes(count):


### PR DESCRIPTION
## Summary
- clarify field order in `generate_series`
- ensure each tuple contains `metro_distance` placeholder

## Testing
- `python3 -m py_compile server/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_683ffcda139c8324be134f3c67640a06