### PR TITLE
Fix missing google services configuration

### DIFF
--- a/my_notes_app/README.md
+++ b/my_notes_app/README.md
@@ -18,6 +18,7 @@ A Flutter application for managing notes. Users can log in, view and save notes 
    ```
 
    The repository already contains `google-services.json` for Firebase Android configuration.
+   The file is located in `android/app` so no additional setup is required.
 
 ## Running
 

--- a/my_notes_app/android/app/google-services.json
+++ b/my_notes_app/android/app/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "406501490924",
+    "project_id": "notes-3de4b",
+    "storage_bucket": "notes-3de4b.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:406501490924:android:d5969de880e708cfbae5c9",
+        "android_client_info": {
+          "package_name": "com.example.my_notes_app"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyA6st5Rr59g2je68Diy0562arPiWIJBqRw"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Summary
- include `google-services.json` inside android/app
- clarify README location of google config file

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401cb5108c83248f850603eb074d5b